### PR TITLE
remove processing gc/map in `getGender` function

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -153,7 +153,7 @@ loadReadCountsFromWig <- function(counts, chrs = c(1:22, "X", "Y"), gc = NULL, m
 		  counts <- filterByMappabilityScore(counts, map=map, mapScoreThres = mapScoreThres)
 		}
 		## get gender ##
-		gender <- getGender(counts.raw, counts, gc, map, fracReadsInChrYForMale = fracReadsInChrYForMale, 
+		gender <- getGender(counts.raw, counts, gc = NULL, map = NULL, fracReadsInChrYForMale = fracReadsInChrYForMale, 
 							chrXMedianForMale = chrXMedianForMale, useChrY = useChrY,
 							centromere=centromere, flankLength=flankLength, targetedSequences = targetedSequences,
 							genomeStyle = genomeStyle)


### PR DESCRIPTION
useful when chrY is used, but not available for GC / mappability